### PR TITLE
Installation via Chocolatey

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+choco/** linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build/
 *.html
 *.css
 *.js
+
+# choco
+choco/src/dynstat.php
+*.nupkg

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ You can detect that your script is being executed by dynstat to produce a static
 
 - `BUILD_NAME` (string)
 
+## Install
+
+To have access to the `dynstat` command anywhere, you can install dynstat with Chocolatey, simply run the following command in Command Prompt (Admin):
+
+```batch
+powershell -command "(New-Object Net.WebClient).DownloadFile('https://calamity.gg/chocolatey/dynstat.nupkg', 'dynstat.nupkg')" && choco install dynstat -s . -y && del dynstat.nupkg
+```
+
 ## Credits
 
 The minify option is powered by [Mecha CMS' Minify Engine](https://github.com/mecha-cms/x.minify).

--- a/choco/make-nupkg.bat
+++ b/choco/make-nupkg.bat
@@ -1,0 +1,6 @@
+del "src\dynstat.php"
+copy "..\dynstat.php" "src\dynstat.php" /a
+cd src
+choco pack
+cd ..
+for /r "src" %%x in (*.nupkg) do move "%%x" .

--- a/choco/src/chocolateyInstall.ps1
+++ b/choco/src/chocolateyInstall.ps1
@@ -1,0 +1,3 @@
+$installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+Install-ChocolateyPath "$installDir\path"

--- a/choco/src/dynstat.nuspec
+++ b/choco/src/dynstat.nuspec
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>dynstat</id>
+    <version>1.0.0</version>
+    <description>Why is this a required field?</description>
+    <authors>Why is this a required field?</authors>
+  </metadata>
+</package>

--- a/choco/src/path/dynstat
+++ b/choco/src/path/dynstat
@@ -1,0 +1,3 @@
+#!/bin/bash
+pathDir=$(dirname "$0")
+php "$pathDir/../dynstat.php" "$@"

--- a/choco/src/path/dynstat.bat
+++ b/choco/src/path/dynstat.bat
@@ -1,0 +1,3 @@
+@echo off
+SET pathDir=%~dp0
+php "%pathDir%..\dynstat.php" %*


### PR DESCRIPTION
Since Chocolatey 2.0.0 is now released, we should be able to deploy dynstat to choco.calamity.gg similarly to Pluto.